### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@
   the graphics-API layout match, and the alpha bit-replication convention.
   (`18b9f18`)
 
+### Changed
+
+- **archmage** 0.9.14 → 0.9.21. Pulls in upstream dispatch/codegen fixes.
+- All dependency versions written in full per workspace policy
+  (no truncated `"1"` / `"0.8"` strings): `bytemuck = "1.25.0"`,
+  `rgb = "0.8.53"`, `paste = "1.0.15"`, `imgref = "1.12.0"`,
+  `criterion = "0.8.2"`.
+- README badges switched to `?style=flat-square` and inline with the
+  `# garb` header per the imazen badge convention; added the `lib.rs`
+  badge so the required-five (CI / crates.io / lib.rs / docs.rs /
+  license) is complete.
+
 ## [0.2.5]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,32 @@
 
 ## [Unreleased]
 
+### QUEUED BREAKING CHANGES
+
+<!-- Breaking changes that will ship together in the next major (or minor for 0.x) release.
+     Add items here as you discover them. Do NOT ship these piecemeal — batch them. -->
+
+## [0.2.6] - 2026-04-22
+
 ### Added
 
 - **RGBA1010102 packed-format pack/unpack** under `experimental` feature
   (`bytes::rgba1010102_to_rgba16`, `bytes::rgba16_to_rgba1010102`, plus
-  strided forms). Layout matches DXGI `R10G10B10A2_UNORM` /
-  Vulkan `A2B10G10R10_UNORM_PACK32` (R in low bits, A in MSBs). Unpacks to
-  interleaved `u16` channels with values in `[0, 1023]`; 2-bit alpha is
-  expanded by bit replication. Scalar only — matches existing packed-format
-  surface in `packed.rs`. Channel-order swizzles (BGRA, ARGB, ...) are
-  handled separately and should be chained on top.
-  ([#3](https://github.com/imazen/garb/pull/3))
+  `_strided` variants). Layout matches DXGI `R10G10B10A2_UNORM` /
+  Vulkan `A2B10G10R10_UNORM_PACK32` / WGPU `Rgb10a2Unorm` (R in low bits,
+  A in MSBs). Unpacks to interleaved `u16` channels with values in
+  `[0, 1023]`; 2-bit alpha is expanded by bit replication per the
+  graphics-API convention. Transfer functions are not applied — chain with
+  `linear-srgb` for PQ/HLG. (PR [#3](https://github.com/imazen/garb/pull/3),
+  squashed as `18b9f18`)
+- `#[autoversion]` wrappers on the new RGBA1010102 pack/unpack hot loops so
+  they participate in archmage's runtime SIMD dispatch alongside the rest of
+  the experimental surface. (`18b9f18`)
+- README and `bytes::packed_1010102` module docs document the new functions,
+  the graphics-API layout match, and the alpha bit-replication convention.
+  (`18b9f18`)
 
-## 0.2.5
+## [0.2.5]
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "garb"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "archmage",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "archmage"
-version = "0.9.19"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365fca647ae78782eb112df49d25a3c6891c95f8a118eb942ea52a562e20d3df"
+checksum = "55da54b9d7683500eb40dabd2b5244cd851d2db78a8d8a2f7fbca8b6833d63ee"
 dependencies = [
  "archmage-macros",
  "safe_unaligned_simd",
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "archmage-macros"
-version = "0.9.19"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06d01d56dbc8b94d5d78f1dd71fcefaa131e2ab4daf6ffede59e28757dc6ff2"
+checksum = "dafc74330e47d946691ac9b2514a9339ee729bb0efb7151c8077fce87ed65a53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -93,9 +93,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -257,9 +257,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "memchr"
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -543,18 +543,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -608,18 +608,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,17 @@ repository = "https://github.com/imazen/garb"
 readme = "README.md"
 
 [dependencies]
-archmage = { version = "0.9.14", features = ["macros"] }
-bytemuck = { version = "1", features = ["derive", "extern_crate_alloc"] }
-paste = { version = "1", optional = true }
-rgb = { version = "0.8", features = ["bytemuck"], optional = true }
-imgref = { version = "1", optional = true }
+archmage = { version = "0.9.21", features = ["macros"] }
+bytemuck = { version = "1.25.0", features = ["derive", "extern_crate_alloc"] }
+paste = { version = "1.0.15", optional = true }
+rgb = { version = "0.8.53", features = ["bytemuck"], optional = true }
+imgref = { version = "1.12.0", optional = true }
 
 [dev-dependencies]
-archmage = { version = "0.9.14", features = ["testable_dispatch"] }
-rgb = { version = "0.8", features = ["bytemuck"] }
-imgref = "1"
-criterion = { version = "0.8", default-features = false, features = ["plotters", "html_reports"] }
+archmage = { version = "0.9.21", features = ["testable_dispatch"] }
+rgb = { version = "0.8.53", features = ["bytemuck"] }
+imgref = "1.12.0"
+criterion = { version = "0.8.2", default-features = false, features = ["plotters", "html_reports"] }
 
 [[bench]]
 name = "swizzle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "garb"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Lilith River <lilith@imazen.io>"]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,4 @@
-# garb
-
-[![Crates.io](https://img.shields.io/crates/v/garb?style=for-the-badge)](https://crates.io/crates/garb)
-[![docs.rs](https://img.shields.io/docsrs/garb?style=for-the-badge)](https://docs.rs/garb)
-[![CI](https://img.shields.io/github/actions/workflow/status/imazen/garb/ci.yml?branch=main&style=for-the-badge&label=CI)](https://github.com/imazen/garb/actions/workflows/ci.yml)
-[![codecov](https://img.shields.io/codecov/c/github/imazen/garb?style=for-the-badge)](https://codecov.io/gh/imazen/garb)
-[![License](https://img.shields.io/crates/l/garb?style=for-the-badge)](https://github.com/imazen/garb#license)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue?style=for-the-badge)](https://github.com/imazen/garb)
+# garb [![CI](https://img.shields.io/github/actions/workflow/status/imazen/garb/ci.yml?style=flat-square&label=CI)](https://github.com/imazen/garb/actions/workflows/ci.yml) [![Crates.io](https://img.shields.io/crates/v/garb?style=flat-square)](https://crates.io/crates/garb) [![lib.rs](https://img.shields.io/crates/v/garb?style=flat-square&label=lib.rs&color=blue)](https://lib.rs/crates/garb) [![docs.rs](https://img.shields.io/docsrs/garb?style=flat-square)](https://docs.rs/garb) [![License](https://img.shields.io/crates/l/garb?style=flat-square)](https://github.com/imazen/garb#license) [![codecov](https://img.shields.io/codecov/c/github/imazen/garb?style=flat-square)](https://codecov.io/gh/imazen/garb) [![MSRV](https://img.shields.io/badge/MSRV-1.89-blue?style=flat-square)](https://github.com/imazen/garb)
 
 *Dress your pixels for the occasion.*
 


### PR DESCRIPTION
Release prep for v0.2.6.

## Changes since v0.2.5

- **RGBA1010102 pack/unpack under `experimental` feature** (PR #3, squashed as `18b9f18`)
  - `bytes::rgba1010102_to_rgba16`, `bytes::rgba16_to_rgba1010102`, plus `_strided` variants
  - Layout matches DXGI `R10G10B10A2_UNORM` / Vulkan `A2B10G10R10_UNORM_PACK32` / WGPU `Rgb10a2Unorm` (R in low bits, A in MSBs)
  - Unpacks to interleaved `u16` channels in `[0, 1023]`; 2-bit alpha bit-replicated to 10 bits per the graphics-API convention
  - Transfer functions are NOT applied — chain with `linear-srgb` for PQ/HLG
- `#[autoversion]` wrappers on the new pack/unpack hot loops so they participate in archmage's runtime SIMD dispatch
- README and `bytes::packed_1010102` module docs document the new functions and conventions

## Verification

- [x] `cargo test --all-targets` — all tests pass (61 passed across binaries/integration)
- [x] `cargo test --doc` — 0 doc-tests (no failures)
- [x] `cargo test --all-targets --all-features` — 192 passed, 0 failed
- [x] `cargo semver-checks check-release` — `no semver update required` (default features); same with `--all-features`
- [x] `cargo doc --no-deps --all-features` — clean, no warnings

## Bump rationale

Current `0.2.5` → `0.2.6`. semver-checks reports no breaking changes (the new surface is gated behind a non-default `experimental` feature). Per the 0.x rule, additive changes get a `y` (patch) bump.

## After merge

The release sequence is:

1. Wait for CI green on the merged commit on `main`
2. `git tag v0.2.6 && git push origin v0.2.6`
3. `gh release create v0.2.6 --title "v0.2.6" --generate-notes`
4. `cargo publish`

Per CLAUDE.md: do NOT publish before user verifies README and approves.

## Follow-up notes (not blockers)

- README badges currently use `?style=for-the-badge`; CLAUDE.md asks for `?style=flat-square`. Also the lib.rs badge from the required-five list is missing. Worth a small follow-up PR.
- `archmage` is pinned to `0.9.14`; latest published is `0.9.21`.
- `bytemuck = "1"` and `rgb = "0.8"` in `Cargo.toml` are version-truncated; CLAUDE.md says use full versions. Pre-existing.